### PR TITLE
Fix Write Empty Data Set

### DIFF
--- a/src/file_io.py
+++ b/src/file_io.py
@@ -28,13 +28,9 @@ def write_to_csv(data_list: list, outfile: File):
     if not os.path.exists(outfile.path):
         os.makedirs(outfile.path)
 
-    if len(data_list) == 0:
-        # Create an empty file
-        with open(outfile.filename(), 'w', encoding='utf-8') as _:
-            pass
-        return
-
     with open(outfile.filename(), 'w', encoding='utf-8') as out_file:
+        if len(data_list) == 0:
+            return
         headers = [f.name for f in fields(data_list[0])]
         data_tuple = [astuple(x) for x in data_list]
 

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -23,14 +23,21 @@ class File:
 def write_to_csv(data_list: list, outfile: File):
     """Writes `data_list` to `filename` as csv"""
     print(f"dumping {len(data_list)} results to {outfile.name}")
-    headers = [f.name for f in fields(data_list[0])]
-    data_tuple = [astuple(x) for x in data_list]
 
     # Creates out path if it doesn't exist.
     if not os.path.exists(outfile.path):
         os.makedirs(outfile.path)
 
+    if len(data_list) == 0:
+        # Create an empty file
+        with open(outfile.filename(), 'w', encoding='utf-8') as _:
+            pass
+        return
+
     with open(outfile.filename(), 'w', encoding='utf-8') as out_file:
+        headers = [f.name for f in fields(data_list[0])]
+        data_tuple = [astuple(x) for x in data_list]
+
         dict_writer = csv.DictWriter(out_file, headers, lineterminator='\n')
         dict_writer.writeheader()
         writer = csv.writer(out_file, lineterminator='\n')


### PR DESCRIPTION
In a previous PR (#4), I was naively convinced that we should continue to write on an empty data set. [The](https://github.com/bh2smith/cow-solver-rewards/pull/2#discussion_r818793867)

Unfortunately it was overlooked that the headers of the dataset are taken from the first entry of the dataset and this resulted in an index error. We fix this here.