### PR TITLE
Slippage query improvement: Filter out non allowed buffer trades

### DIFF
--- a/queries/slippage/subquery_batchwise_internal_transfers.sql
+++ b/queries/slippage/subquery_batchwise_internal_transfers.sql
@@ -183,44 +183,50 @@ buffer_trades as (
              full outer join valued_potential_buffered_trades b
                              on a.tx_hash = b.tx_hash
     where (
-              case
-                  when a.clearing_value is not null and
-                       b.clearing_value is not null
-                      -- If clearing prices are use, the price of internal trades are usually pretty close to
-                      -- the clearing prices. But they don't have to be the same, as internal trades are usually settled 
-                      -- at the effective rate of an AMM. One example with deviating prices, is the tx:
-                      -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c. It 
-                      -- scores a matchablity of 0.021. 
-                      -- Another example is xd2e1eeef702d562491d6b68683772fec1b119df18e338b50f45ed4751c89e406 with a
-                      -- matchablity of 0.02 for USDC to ETH trade
-                      -- But for higher values, one more commonly find examples, where solvers sell a little bit too much
-                      -- of the selling token and hence also receive a little bit too much of the buying token
-                      -- One could see this as an internal buffer trade, but since this is not good for the protocol's buffers
-                      -- we will not evalute this as buffer trade, but rather as positive and negative slippage at the same time:
-                      -- One example is: 0x63e234a1a0d657f5725817f8d829c4e14d8194fdc49b5bc09322179ff99619e7 with a matchablity of 0.26
-                      -- selling too much usdc and receiving too much eth
-                      then (abs((a.clearing_value + b.clearing_value) /
-                               (abs(a.clearing_value) + abs(b.clearing_value))) <
-                           0.025 
-                           and a.token != b.token)
-                  else case
-                           when a.usd_value is not null and b.usd_value is not null
-                                -- If prices from the prices.usd dune table are used, the prices can also be off from time to time.
-                                -- On the one hand side, we don't wanna allow to high deviations. E.g. for
-                                -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c a matchability of 0.26 is calculated
-                                -- for a slippage of WETH and the LDO deficit. (In this example the internal trade is only STRONG -> LDO)
-                                -- On the other hand side, real internal trades like the CRV to USDT internal trade of 0xc15dda7c10eb317c0ad177316020ec4baa13babb0713b73480feef14045603f4
-                                -- also score a matchablilty of 0.027
-                                -- As a compromise 0.025 was chosen
-                               then (abs((a.usd_value + b.usd_value) /
-                                        (abs(a.usd_value) + abs(b.usd_value))) <
-                                    0.025 
-                                    and a.token != b.token
-                                    and abs(a.usd_value) > 10 -- we don't want small slippage values to be recognized as internal swaps
-                                    )
-                           else false
-                      end
-                  end
+             case 
+                when (a.amount > 0 and b.amount < 0 and a.token in (Select * from allow_listed_tokens)) or (b.amount > 0 and a.amount < 0 and b.token in (Select * from allow_listed_tokens))
+                then
+                case
+                    when a.clearing_value is not null and
+                        b.clearing_value is not null
+                        -- If clearing prices are use, the price of internal trades are usually pretty close to
+                        -- the clearing prices. But they don't have to be the same, as internal trades are usually settled 
+                        -- at the effective rate of an AMM. One example with deviating prices, is the tx:
+                        -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c. It 
+                        -- scores a matchablity of 0.021.
+                        -- Another example is xd2e1eeef702d562491d6b68683772fec1b119df18e338b50f45ed4751c89e406 with a
+                        -- matchablity of 0.02 for USDC to ETH trade
+                        -- But for higher values, one more commonly find examples, where solvers sell a little bit too much
+                        -- of the selling token and hence also receive a little bit too much of the buying token
+                        -- One could see this as an internal buffer trade, but since this is not good for the protocol's buffers
+                        -- we will not evalute this as buffer trade, but rather as positive and negative slippage at the same time:
+                        -- One example is: 0x63e234a1a0d657f5725817f8d829c4e14d8194fdc49b5bc09322179ff99619e7 with a matchablity of 0.26
+                        -- selling too much usdc and receiving too much eth
+                        then (abs((a.clearing_value + b.clearing_value) /
+                                (abs(a.clearing_value) + abs(b.clearing_value))) <
+                            0.025
+                            and a.token != b.token)
+                    else case
+                            when a.usd_value is not null and b.usd_value is not null
+                                    -- If prices from the prices.usd dune table are used, the prices can also be off from time to time.
+                                    -- On the one hand side, we don't wanna allow to high deviations. E.g. for
+                                    -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c a matchability of 0.26 is calculated
+                                    -- for a slippage of WETH and the LDO deficit. (In this example the internal trade is only STRONG -> LDO)
+                                    -- On the other hand side, real internal trades like the CRV to USDT internal trade of 0xc15dda7c10eb317c0ad177316020ec4baa13babb0713b73480feef14045603f4
+                                    -- also score a matchablilty of 0.027
+                                    -- As a compromise 0.025 was chosen
+                                then (abs((a.usd_value + b.usd_value) /
+                                            (abs(a.usd_value) + abs(b.usd_value))) <
+                                        0.025
+                                        and a.token != b.token
+                                        and abs(a.usd_value) > 10 -- we don't want small slippage values to be recognized as internal swaps
+                                        )
+                            else false
+                        end
+                    end
+                else
+                    false
+                end
               )
 ),
 incoming_and_outgoing_with_buffer_trades as (

--- a/queries/slippage/subquery_batchwise_internal_transfers.sql
+++ b/queries/slippage/subquery_batchwise_internal_transfers.sql
@@ -184,6 +184,7 @@ buffer_trades as (
                              on a.tx_hash = b.tx_hash
     where (
             case 
+                -- in order to classify as buffer trade, the postive surplus must be in an allow_listed token
                 when (a.amount > 0 and b.amount < 0 and a.token in (Select * from allow_listed_tokens)) 
                     or (b.amount > 0 and a.amount < 0 and b.token in (Select * from allow_listed_tokens))
                 then

--- a/queries/slippage/subquery_batchwise_internal_transfers.sql
+++ b/queries/slippage/subquery_batchwise_internal_transfers.sql
@@ -183,51 +183,54 @@ buffer_trades as (
              full outer join valued_potential_buffered_trades b
                              on a.tx_hash = b.tx_hash
     where (
-             case 
-                when (a.amount > 0 and b.amount < 0 and a.token in (Select * from allow_listed_tokens)) or (b.amount > 0 and a.amount < 0 and b.token in (Select * from allow_listed_tokens))
+            case 
+                when (a.amount > 0 and b.amount < 0 and a.token in (Select * from allow_listed_tokens)) 
+                    or (b.amount > 0 and a.amount < 0 and b.token in (Select * from allow_listed_tokens))
                 then
-                case
-                    when a.clearing_value is not null and
-                        b.clearing_value is not null
-                        -- If clearing prices are use, the price of internal trades are usually pretty close to
-                        -- the clearing prices. But they don't have to be the same, as internal trades are usually settled 
-                        -- at the effective rate of an AMM. One example with deviating prices, is the tx:
-                        -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c. It 
-                        -- scores a matchablity of 0.021.
-                        -- Another example is xd2e1eeef702d562491d6b68683772fec1b119df18e338b50f45ed4751c89e406 with a
-                        -- matchablity of 0.02 for USDC to ETH trade
-                        -- But for higher values, one more commonly find examples, where solvers sell a little bit too much
-                        -- of the selling token and hence also receive a little bit too much of the buying token
-                        -- One could see this as an internal buffer trade, but since this is not good for the protocol's buffers
-                        -- we will not evalute this as buffer trade, but rather as positive and negative slippage at the same time:
-                        -- One example is: 0x63e234a1a0d657f5725817f8d829c4e14d8194fdc49b5bc09322179ff99619e7 with a matchablity of 0.26
-                        -- selling too much usdc and receiving too much eth
-                        then (abs((a.clearing_value + b.clearing_value) /
-                                (abs(a.clearing_value) + abs(b.clearing_value))) <
-                            0.025
-                            and a.token != b.token)
-                    else case
-                            when a.usd_value is not null and b.usd_value is not null
-                                    -- If prices from the prices.usd dune table are used, the prices can also be off from time to time.
-                                    -- On the one hand side, we don't wanna allow to high deviations. E.g. for
-                                    -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c a matchability of 0.26 is calculated
-                                    -- for a slippage of WETH and the LDO deficit. (In this example the internal trade is only STRONG -> LDO)
-                                    -- On the other hand side, real internal trades like the CRV to USDT internal trade of 0xc15dda7c10eb317c0ad177316020ec4baa13babb0713b73480feef14045603f4
-                                    -- also score a matchablilty of 0.027
-                                    -- As a compromise 0.025 was chosen
-                                then (abs((a.usd_value + b.usd_value) /
-                                            (abs(a.usd_value) + abs(b.usd_value))) <
-                                        0.025
-                                        and a.token != b.token
-                                        and abs(a.usd_value) > 10 -- we don't want small slippage values to be recognized as internal swaps
-                                        )
-                            else false
+                    case
+                        when a.clearing_value is not null and
+                            b.clearing_value is not null
+                            -- If clearing prices are use, the price of internal trades are usually pretty close to
+                            -- the clearing prices. But they don't have to be the same, as internal trades are usually settled 
+                            -- at the effective rate of an AMM. One example with deviating prices, is the tx:
+                            -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c. It 
+                            -- scores a matchablity of 0.021.
+                            -- Another example is xd2e1eeef702d562491d6b68683772fec1b119df18e338b50f45ed4751c89e406 with a
+                            -- matchablity of 0.02 for USDC to ETH trade
+                            -- But for higher values, one more commonly find examples, where solvers sell a little bit too much
+                            -- of the selling token and hence also receive a little bit too much of the buying token
+                            -- One could see this as an internal buffer trade, but since this is not good for the protocol's buffers
+                            -- we will not evalute this as buffer trade, but rather as positive and negative slippage at the same time:
+                            -- One example is: 0x63e234a1a0d657f5725817f8d829c4e14d8194fdc49b5bc09322179ff99619e7 with a matchablity of 0.26
+                            -- selling too much usdc and receiving too much eth
+                            then (abs((a.clearing_value + b.clearing_value) /
+                                    (abs(a.clearing_value) + abs(b.clearing_value))) <
+                                0.025
+                                and a.token != b.token)
+                        else 
+                            case
+                                when a.usd_value is not null and b.usd_value is not null
+                                        -- If prices from the prices.usd dune table are used, the prices can also be off from time to time.
+                                        -- On the one hand side, we don't wanna allow to high deviations. E.g. for
+                                        -- 0x9a318d1abd997bcf8afed55b2946a7b1bd919d227f094cdcc99d8d6155808d7c a matchability of 0.26 is calculated
+                                        -- for a slippage of WETH and the LDO deficit. (In this example the internal trade is only STRONG -> LDO)
+                                        -- On the other hand side, real internal trades like the CRV to USDT internal trade of 0xc15dda7c10eb317c0ad177316020ec4baa13babb0713b73480feef14045603f4
+                                        -- also score a matchablilty of 0.027
+                                        -- As a compromise 0.025 was chosen
+                                    then (abs((a.usd_value + b.usd_value) /
+                                                (abs(a.usd_value) + abs(b.usd_value))) <
+                                            0.025
+                                            and a.token != b.token
+                                            and abs(a.usd_value) > 10 -- we don't want small slippage values to be recognized as internal swaps
+                                            )
+                                else 
+                                false
+                            end
                         end
-                    end
-                else
-                    false
+                    else
+                        false
                 end
-              )
+            )
 ),
 incoming_and_outgoing_with_buffer_trades as (
     select *

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -5,22 +5,22 @@ from pprint import pprint
 from src.dune_analytics import DuneAnalytics, QueryParameter
 from src.file_io import File
 from src.models import Network
-from src.token_list import HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL, get_trusted_tokens_from_url
+from src.token_list import ALLOWED_TOKEN_LIST_URL, get_trusted_tokens_from_url
 
 
 def generate_sql_query_for_allowed_token_list(token_list) -> str:
     query = "allow_listed_tokens as ( Select * from (VALUES"
     for address in token_list:
-        query = "".join([query, f"('\\{address[1:]}' :: bytea),"])
+        query += f"('\\{address[1:]}' :: bytea),"
     query = query[:-1]
-    query = "".join([query, ") AS t (token)),"])
+    query += ") AS t (token)),"
     return query
 
 
 def add_token_list_table_to_query(original_sub_query: str) -> str:
     '''Inserts a the token_list table right after the WITH statement into the sql query'''
     token_list = get_trusted_tokens_from_url(
-        HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL)
+        ALLOWED_TOKEN_LIST_URL)
     sql_query_for_allowed_token_list = generate_sql_query_for_allowed_token_list(
         token_list)
     return "\n".join(

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -17,19 +17,26 @@ def generate_sql_query_for_allowed_token_list(token_list) -> str:
     return query
 
 
+def adds_table_after_with_statement(query, table_to_add):
+    if query[0:4].lower() != "with":
+        raise ValueError(f"Type {query} does not start with 'with'!")
+    return "\n".join(
+        [
+            query[0:4],
+            table_to_add,
+            query[5:],
+        ]
+    )
+
+
 def add_token_list_table_to_query(original_sub_query: str) -> str:
     '''Inserts a the token_list table right after the WITH statement into the sql query'''
     token_list = get_trusted_tokens_from_url(
         ALLOWED_TOKEN_LIST_URL)
     sql_query_for_allowed_token_list = generate_sql_query_for_allowed_token_list(
         token_list)
-    return "\n".join(
-        [
-            original_sub_query[0:5],
-            sql_query_for_allowed_token_list,
-            original_sub_query[5:],
-        ]
-    )
+    return adds_table_after_with_statement(original_sub_query,
+                                           sql_query_for_allowed_token_list)
 
 
 def slippage_query(dune: DuneAnalytics) -> str:

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -9,11 +9,9 @@ from src.token_list import ALLOWED_TOKEN_LIST_URL, get_trusted_tokens_from_url
 
 
 def generate_sql_query_for_allowed_token_list(token_list) -> str:
-    query = "allow_listed_tokens as ( Select * from (VALUES"
-    for address in token_list:
-        query += f"('\\{address[1:]}' :: bytea),"
-    query = query[:-1]
-    query += ") AS t (token)),"
+    values = ",".join(
+        f"('\\{address[1:]}' :: bytea)" for address in token_list)
+    query = f"allow_listed_tokens as (select * from (VALUES {values}) AS t (token)),"
     return query
 
 

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -5,15 +5,40 @@ from pprint import pprint
 from src.dune_analytics import DuneAnalytics, QueryParameter
 from src.file_io import File
 from src.models import Network
+from src.token_list import HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL, get_trusted_tokens_from_url
+
+
+def generate_sql_query_for_allowed_token_list(token_list) -> str:
+    query = "allow_listed_tokens as ( Select * from (VALUES"
+    for address in token_list:
+        query += f"('\{address[1:]}' :: bytea),"
+    query = query[:-1]
+    query += ") AS t (token)),"
+    return query
+
+
+def build_subquery(dune: DuneAnalytics) -> str:
+    slippage_subquery = File("subquery_batchwise_internal_transfers.sql", path)
+    token_list = get_trusted_tokens_from_url(
+        HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL)
+    sql_query_for_allowed_token_list = generate_sql_query_for_allowed_token_list(
+        token_list)
+    slippage_query = dune.open_query(slippage_subquery.filename())
+    return "\n".join(
+        [
+            slippage_query[0:5],
+            sql_query_for_allowed_token_list,
+            slippage_query[5:],
+        ]
+    )
 
 
 def slippage_query(dune: DuneAnalytics) -> str:
     path = "./queries/slippage"
-    slippage_subquery = File("subquery_batchwise_internal_transfers.sql", path)
     select_slippage = File("select_slippage_results.sql", path)
     return "\n".join(
         [
-            dune.open_query(slippage_subquery.filename()),
+            build_subquery(dune),
             dune.open_query(select_slippage.filename())
         ]
     )
@@ -38,7 +63,8 @@ def get_period_slippage(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Fetch Accounting Period Totals")
+    parser = argparse.ArgumentParser(
+        description="Fetch Accounting Period Totals")
     parser.add_argument(
         "--start",
         type=str,

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -15,7 +15,7 @@ def generate_sql_query_for_allowed_token_list(token_list) -> str:
     return query
 
 
-def adds_table_after_with_statement(query, table_to_add):
+def prepend_to_sub_query(query, table_to_add):
     if query[0:4].lower() != "with":
         raise ValueError(f"Type {query} does not start with 'with'!")
     return "\n".join(
@@ -28,13 +28,12 @@ def adds_table_after_with_statement(query, table_to_add):
 
 
 def add_token_list_table_to_query(original_sub_query: str) -> str:
-    '''Inserts a the token_list table right after the WITH statement into the sql query'''
-    token_list = get_trusted_tokens_from_url(
-        ALLOWED_TOKEN_LIST_URL)
+    """Inserts a the token_list table right after the WITH statement into the sql query"""
+    token_list = get_trusted_tokens_from_url(ALLOWED_TOKEN_LIST_URL)
     sql_query_for_allowed_token_list = generate_sql_query_for_allowed_token_list(
         token_list)
-    return adds_table_after_with_statement(original_sub_query,
-                                           sql_query_for_allowed_token_list)
+    return prepend_to_sub_query(original_sub_query,
+                                sql_query_for_allowed_token_list)
 
 
 def slippage_query(dune: DuneAnalytics) -> str:

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -11,9 +11,9 @@ from src.token_list import HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL, get_tru
 def generate_sql_query_for_allowed_token_list(token_list) -> str:
     query = "allow_listed_tokens as ( Select * from (VALUES"
     for address in token_list:
-        query += f"('\{address[1:]}' :: bytea),"
+        query = "".join([query, f"('\\{address[1:]}' :: bytea),"])
     query = query[:-1]
-    query += ") AS t (token)),"
+    query = "".join([query, ") AS t (token)),"])
     return query
 
 
@@ -34,12 +34,14 @@ def add_token_list_table_to_query(original_sub_query: str) -> str:
 
 def slippage_query(dune: DuneAnalytics) -> str:
     path = "./queries/slippage"
-    slippage_subquery = File("subquery_batchwise_internal_transfers.sql", path)
-    select_slippage = File("select_slippage_results.sql", path)
+    slippage_sub_query = dune.open_query(
+        File("subquery_batchwise_internal_transfers.sql", path).filename())
+    select_slippage_query = dune.open_query(
+        File("select_slippage_results.sql", path).filename())
     return "\n".join(
         [
-            add_token_list_table_to_query(slippage_subquery),
-            dune.open_query(select_slippage.filename())
+            add_token_list_table_to_query(slippage_sub_query),
+            select_slippage_query
         ]
     )
 

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -17,28 +17,28 @@ def generate_sql_query_for_allowed_token_list(token_list) -> str:
     return query
 
 
-def build_subquery(dune: DuneAnalytics) -> str:
-    slippage_subquery = File("subquery_batchwise_internal_transfers.sql", path)
+def add_token_list_table_to_query(original_sub_query: str) -> str:
+    '''Inserts a the token_list table right after the WITH statement into the sql query'''
     token_list = get_trusted_tokens_from_url(
         HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL)
     sql_query_for_allowed_token_list = generate_sql_query_for_allowed_token_list(
         token_list)
-    slippage_query = dune.open_query(slippage_subquery.filename())
     return "\n".join(
         [
-            slippage_query[0:5],
+            original_sub_query[0:5],
             sql_query_for_allowed_token_list,
-            slippage_query[5:],
+            original_sub_query[5:],
         ]
     )
 
 
 def slippage_query(dune: DuneAnalytics) -> str:
     path = "./queries/slippage"
+    slippage_subquery = File("subquery_batchwise_internal_transfers.sql", path)
     select_slippage = File("select_slippage_results.sql", path)
     return "\n".join(
         [
-            build_subquery(dune),
+            add_token_list_table_to_query(slippage_subquery),
             dune.open_query(select_slippage.filename())
         ]
     )

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -1,0 +1,21 @@
+"""Utility code for fetching the allowed token list"""
+import json
+import requests
+
+HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL = 'https://raw.githubusercontent.com/gnosis/cow-dex-solver/main/data/token_list_for_buffer_trading.json'
+
+
+def get_trusted_tokens(token_list_json: str) -> list[str]:
+    """Get list of trusted token IDs from JSON file.
+    """
+    try:
+        token_list = json.loads(token_list_json)
+    except json.JSONDecodeError:
+        print("Could not parse JSON data!")
+        raise
+    return [token['address'].lower() for token in token_list['tokens']]
+
+
+def get_trusted_tokens_from_url(url: str) -> list[str]:
+    response = requests.get(url)
+    return get_trusted_tokens(response.text)

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -2,6 +2,7 @@
 import json
 import requests
 
+#pylint: disable=line-too-long
 HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL = 'https://raw.githubusercontent.com/gnosis/cow-dex-solver/main/data/token_list_for_buffer_trading.json'
 
 
@@ -17,5 +18,6 @@ def get_trusted_tokens(token_list_json: str) -> list[str]:
 
 
 def get_trusted_tokens_from_url(url: str) -> list[str]:
+    '''Returns the list of trusted buffer tradable tokens'''
     response = requests.get(url)
     return get_trusted_tokens(response.text)

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -6,7 +6,7 @@ HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL = 'https://raw.githubusercontent.co
 
 
 def get_trusted_tokens(token_list_json: str) -> list[str]:
-    """Get list of trusted token IDs from JSON file.
+    """Get list of trusted token IDs from JSON-str.
     """
     try:
         token_list = json.loads(token_list_json)

--- a/src/token_list.py
+++ b/src/token_list.py
@@ -3,7 +3,7 @@ import json
 import requests
 
 #pylint: disable=line-too-long
-HOSTED_ALLOWED_BUFFER_TRADING_TOKEN_LIST_URL = 'https://raw.githubusercontent.com/gnosis/cow-dex-solver/main/data/token_list_for_buffer_trading.json'
+ALLOWED_TOKEN_LIST_URL = 'https://raw.githubusercontent.com/gnosis/cow-dex-solver/main/data/token_list_for_buffer_trading.json'
 
 
 def get_trusted_tokens(token_list_json: str) -> list[str]:

--- a/tests/e2e/test_internal_trades.py
+++ b/tests/e2e/test_internal_trades.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import datetime
 
 from src.dune_analytics import DuneAnalytics, QueryParameter
-from src.fetch.period_slippage import build_subquery
+from src.fetch.period_slippage import add_token_list_table_to_query
 from src.file_io import File
 from src.models import Address, InternalTokenTransfer, Network
 
@@ -25,9 +25,10 @@ def get_internal_transfers(
 ) -> list[InternalTokenTransfer]:
     path = "./queries/slippage"
     select_transfers_file = File("select_in_out_with_buffers.sql", path)
+    slippage_subquery = File("subquery_batchwise_internal_transfers.sql", path)
     query = "\n".join(
         [
-            build_subquery(dune),
+            add_token_list_table_to_query(slippage_subquery),
             dune.open_query(select_transfers_file.filename())
         ]
     )

--- a/tests/e2e/test_internal_trades.py
+++ b/tests/e2e/test_internal_trades.py
@@ -114,8 +114,9 @@ class TestDuneAnalytics(unittest.TestCase):
     def test_does_recognize_slippage_due_to_buffer_token_list(self):
         """
         tx: 0x0bd527494e8efbf4c3013d1e355976ed90fa4e3b79d1f2c2a2690b02baae4abe
-        This tx has a internal trade between pickle and eth. As pickle is not in the allow-list, hence 
-        the internal trade was not allowed, our queries should recognized it as slippage as not as a internal trade. 
+        This tx has a internal trade between pickle and eth. As pickle is not in the allow-list, 
+        the internal trade was not allowed.
+        Our queries should recognized these kind of trades as slippage and not as a internal trades. 
         """
         internal_transfers = get_internal_transfers(
             dune=self.dune_connection,

--- a/tests/e2e/test_internal_trades.py
+++ b/tests/e2e/test_internal_trades.py
@@ -114,8 +114,8 @@ class TestDuneAnalytics(unittest.TestCase):
     def test_does_recognize_slippage_due_to_buffer_token_list(self):
         """
         tx: 0x0bd527494e8efbf4c3013d1e355976ed90fa4e3b79d1f2c2a2690b02baae4abe
-        This tx scores a deficit in eth and a surplus in pickle. As pickle is not in the allow-list
-        it is recognized as slippage.
+        This tx has a internal trade between pickle and eth. As pickle is not in the allow-list, hence 
+        the internal trade was not allowed, our queries should recognized it as slippage as not as a internal trade. 
         """
         internal_transfers = get_internal_transfers(
             dune=self.dune_connection,

--- a/tests/e2e/test_internal_trades.py
+++ b/tests/e2e/test_internal_trades.py
@@ -24,12 +24,14 @@ def get_internal_transfers(
         period_end: datetime
 ) -> list[InternalTokenTransfer]:
     path = "./queries/slippage"
-    select_transfers_file = File("select_in_out_with_buffers.sql", path)
-    slippage_subquery = File("subquery_batchwise_internal_transfers.sql", path)
+    select_transfers_query = dune.open_query(
+        File("select_in_out_with_buffers.sql", path).filename())
+    slippage_sub_query = dune.open_query(
+        File("subquery_batchwise_internal_transfers.sql", path).filename())
     query = "\n".join(
         [
-            add_token_list_table_to_query(slippage_subquery),
-            dune.open_query(select_transfers_file.filename())
+            add_token_list_table_to_query(slippage_sub_query),
+            select_transfers_query
         ]
     )
     data_set = dune.fetch(

--- a/tests/unit/test_token_list_table.py
+++ b/tests/unit/test_token_list_table.py
@@ -1,5 +1,5 @@
 import unittest
-from src.fetch.period_slippage import adds_table_after_with_statement, generate_sql_query_for_allowed_token_list
+from src.fetch.period_slippage import prepend_to_sub_query, generate_sql_query_for_allowed_token_list
 
 
 class TestQueryBuilding(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestQueryBuilding(unittest.TestCase):
     def test_adds_table_after_with_statement(self):
         test_query = "WITH  Select * from table"
         table_to_add = "table as (Select * from other_table)"
-        result_query = adds_table_after_with_statement(
+        result_query = prepend_to_sub_query(
             test_query, table_to_add)
         expected_query = "WITH\ntable as (Select * from other_table)\n Select * from table"
         self.assertEqual(result_query, expected_query)

--- a/tests/unit/test_token_list_table.py
+++ b/tests/unit/test_token_list_table.py
@@ -1,0 +1,15 @@
+import unittest
+from src.fetch.period_slippage import generate_sql_query_for_allowed_token_list
+
+
+class TestQueryBuilding(unittest.TestCase):
+
+    def test_builds_intended_query(self):
+        list = ['0xde1c59bc25d806ad9ddcbe246c4b5e5505645718']
+        expected_query = "allow_listed_tokens as ( Select * from (VALUES('\\xde1c59bc25d806ad9ddcbe246c4b5e5505645718' :: bytea)) AS t (token)),"
+        query = generate_sql_query_for_allowed_token_list(list)
+        self.assertEqual(query, expected_query)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_token_list_table.py
+++ b/tests/unit/test_token_list_table.py
@@ -1,5 +1,5 @@
 import unittest
-from src.fetch.period_slippage import generate_sql_query_for_allowed_token_list
+from src.fetch.period_slippage import adds_table_after_with_statement, generate_sql_query_for_allowed_token_list
 
 
 class TestQueryBuilding(unittest.TestCase):
@@ -9,6 +9,14 @@ class TestQueryBuilding(unittest.TestCase):
         expected_query = "allow_listed_tokens as ( Select * from (VALUES('\\xde1c59bc25d806ad9ddcbe246c4b5e5505645718' :: bytea)) AS t (token)),"
         query = generate_sql_query_for_allowed_token_list(list)
         self.assertEqual(query, expected_query)
+
+    def test_adds_table_after_with_statement(self):
+        test_query = "WITH  Select * from table"
+        table_to_add = "table as (Select * from other_table)"
+        result_query = adds_table_after_with_statement(
+            test_query, table_to_add)
+        expected_query = "WITH\ntable as (Select * from other_table)\n Select * from table"
+        self.assertEqual(result_query, expected_query)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_token_list_table.py
+++ b/tests/unit/test_token_list_table.py
@@ -5,8 +5,9 @@ from src.fetch.period_slippage import adds_table_after_with_statement, generate_
 class TestQueryBuilding(unittest.TestCase):
 
     def test_builds_intended_query(self):
-        list = ['0xde1c59bc25d806ad9ddcbe246c4b5e5505645718']
-        expected_query = "allow_listed_tokens as ( Select * from (VALUES('\\xde1c59bc25d806ad9ddcbe246c4b5e5505645718' :: bytea)) AS t (token)),"
+        list = ['0xde1c59bc25d806ad9ddcbe246c4b5e5505645718',
+                '0x111119bc25d806ad9ddcbe246c4b5e5505645718']
+        expected_query = "allow_listed_tokens as (select * from (VALUES ('\\xde1c59bc25d806ad9ddcbe246c4b5e5505645718' :: bytea),('\\x111119bc25d806ad9ddcbe246c4b5e5505645718' :: bytea)) AS t (token)),"
         query = generate_sql_query_for_allowed_token_list(list)
         self.assertEqual(query, expected_query)
 


### PR DESCRIPTION
In order to make the slippage query more accurate, we are checking one further condition:
We check that the surplus is made in an allowed buffer token for an internal trade. If the surplus is not made in an allowed buffer token, we know that it must be slippage and not an internal trade.

Testplan:
Unit tests only