### PR TITLE
Deduct negative slippage from solver reimbursements

### DIFF
--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 import argparse
+from dataclasses import dataclass
 from datetime import datetime
 from pprint import pprint
 
 from src.dune_analytics import DuneAnalytics, QueryParameter
 from src.file_io import File
-from src.models import Network
+from src.models import Address, Network
 from src.token_list import ALLOWED_TOKEN_LIST_URL, get_trusted_tokens_from_url
 
 
 def generate_sql_query_for_allowed_token_list(token_list) -> str:
-    values = ",".join(
-        f"('\\{address[1:]}' :: bytea)" for address in token_list)
+    values = ",".join(f"('\\{address[1:]}' :: bytea)" for address in token_list)
     query = f"allow_listed_tokens as (select * from (VALUES {values}) AS t (token)),"
     return query
 
@@ -28,7 +30,7 @@ def prepend_to_sub_query(query, table_to_add):
 
 
 def add_token_list_table_to_query(original_sub_query: str) -> str:
-    """Inserts a the token_list table right after the WITH statement into the sql query"""
+    """Inserts the token_list table right after the WITH statement into the sql query"""
     token_list = get_trusted_tokens_from_url(ALLOWED_TOKEN_LIST_URL)
     sql_query_for_allowed_token_list = generate_sql_query_for_allowed_token_list(
         token_list)
@@ -50,12 +52,32 @@ def slippage_query(dune: DuneAnalytics) -> str:
     )
 
 
+@dataclass
+class SolverSlippage:
+    """Total amount reimbursed for accounting period"""
+    solver_address: Address
+    solver_name: str
+    # ETH amount (in WEI) to be deducted from Solver reimbursement
+    amount_wei: int
+
+    @classmethod
+    def from_dict(cls, obj: dict) -> SolverSlippage:
+        """Converts Dune data dict to object with types"""
+        return cls(
+            solver_address=Address(obj['solver_address']),
+            solver_name=obj['solver_name'],
+            # TODO - Reverse the signature of the value
+            amount_wei=int(obj['eth_slippage_wei'])
+        )
+
+
 def get_period_slippage(
         dune: DuneAnalytics,
         period_start: datetime,
         period_end: datetime,
-) -> list:
-    return dune.fetch(
+        allow_positive: bool = True
+) -> list[SolverSlippage]:
+    data_set = dune.fetch(
         query_str=slippage_query(dune),
         network=Network.MAINNET,
         name='Slippage Accounting',
@@ -66,6 +88,13 @@ def get_period_slippage(
             QueryParameter.text_type("ResultTable", "results")
         ]
     )
+    results = []
+    for row in data_set:
+        slippage = SolverSlippage.from_dict(row)
+        if slippage.amount_wei < 0 or allow_positive is True:
+            results.append(slippage)
+
+    return results
 
 
 if __name__ == "__main__":

--- a/src/fetch/period_slippage.py
+++ b/src/fetch/period_slippage.py
@@ -87,6 +87,15 @@ class SplitSlippages:
         else:
             self.positive.append(slippage)
 
+    def __len__(self):
+        return len(self.negative) + len(self.positive)
+
+    def sum_negative(self) -> int:
+        return sum(neg.amount_wei for neg in self.negative)
+
+    def sum_positive(self) -> int:
+        return sum(pos.amount_wei for pos in self.positive)
+
 
 def get_period_slippage(
         dune: DuneAnalytics,

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -69,7 +69,8 @@ class Transfer:
         assert self.receiver == slippage.solver_address, "receiver != solver"
         adjustment = slippage.amount_wei / 10 ** 18
         print(
-            f"Adjusting {self.receiver} transfer by {adjustment:.5f} (slippage)"
+            f"Adjusting {self.receiver}({slippage.solver_name}) "
+            f"transfer by {adjustment:.5f} (slippage)"
         )
         new_amount = self.amount + adjustment
         if new_amount <= 0:

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -1,27 +1,69 @@
+from __future__ import annotations
+
 import argparse
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import Optional
 
 from src.dune_analytics import DuneAnalytics, QueryParameter
+from src.fetch.period_slippage import get_period_slippage
 from src.file_io import File, write_to_csv
-from src.models import Network, Address
+from src.models import Network, Address, SolverSlippage
+from src.utils.dataset import index_by
+
+
+class TokenType(Enum):
+    """
+    Classifications of CSV Airdrop Transfer Types
+    """
+    NATIVE = 'native'
+    ERC20 = 'erc20'
+
+    # Technically the app also supports NFT transfers, but this is irrelevant here
+    # NFT = 'nft'
+
+    @classmethod
+    def from_str(cls, type_str: str) -> TokenType:
+        """Constructs Enum variant from string (case-insensitive)"""
+        try:
+            return cls[type_str.lower()]
+        except KeyError as err:
+            raise ValueError(f"No TransferType {type_str}!") from err
 
 
 @dataclass
 class Transfer:
     """Total amount reimbursed for accounting period"""
-    token_type: str
+    token_type: TokenType
+    # Safe airdrop uses null address for native asset transfers
     token_address: Optional[Address]
     receiver: Address
     # safe-airdrop uses float amounts!
     amount: float
 
-    def __init__(self, token_type, token_address, receiver, amount):
-        self.token_type = token_type
-        self.token_address = Address(token_address) if token_address else None
-        self.receiver = Address(receiver)
-        self.amount = float(amount)
+    @classmethod
+    def from_dict(cls, obj: dict) -> Transfer:
+        """Converts Dune data dict to object with types"""
+        token_type = TokenType.from_str(obj['token_type'])
+        token = Address(
+            obj['token_address']) if token_type != TokenType.NATIVE else None
+        return cls(
+            token_type=token_type,
+            token_address=token,
+            receiver=Address(obj['receiver']),
+            amount=float(obj['amount'])
+        )
+
+    def add_slippage(self, slippage: Optional[SolverSlippage]):
+        if slippage is None:
+            return
+        assert self.receiver == slippage.solver
+        adjustment = slippage.eth_amount_wei / 10 ** 18
+        print(
+            f"Adjusting {self.receiver} transfer by {adjustment:.5f} (slippage)"
+        )
+        self.amount += adjustment
 
 
 def get_transfers(
@@ -29,7 +71,7 @@ def get_transfers(
         period_start: datetime,
         period_end: datetime
 ) -> list[Transfer]:
-    data_set = dune.fetch(
+    reimbursements_and_rewards = dune.fetch(
         query_str=dune.open_query("./queries/period_transfers.sql"),
         network=Network.MAINNET,
         name="Period Transfers",
@@ -37,15 +79,18 @@ def get_transfers(
             QueryParameter.date_type("StartTime", period_start),
             QueryParameter.date_type("EndTime", period_end),
         ])
-    return [
-        Transfer(
-            token_type=row['token_type'],
-            token_address=row['token_address'] or "",
-            receiver=row['receiver'],
-            amount=row['amount'],
-        )
-        for row in data_set
-    ]
+
+    negative_slippage = get_period_slippage(
+        dune, period_start, period_end, allow_positive=False
+    )
+    indexed_slippage = index_by(negative_slippage, 'solver_address')
+
+    results = []
+    for row in reimbursements_and_rewards:
+        transfer = Transfer.from_dict(row)
+        if transfer.token_type == TokenType.NATIVE:
+            transfer.add_slippage(indexed_slippage.get(transfer.receiver))
+        results.append(transfer)
 
 
 if __name__ == "__main__":

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -66,7 +66,7 @@ class Transfer:
     def add_slippage(self, slippage: Optional[SolverSlippage]):
         if slippage is None:
             return
-        assert self.receiver == slippage.solver_address
+        assert self.receiver == slippage.solver_address, "receiver != solver"
         adjustment = slippage.amount_wei / 10 ** 18
         print(
             f"Adjusting {self.receiver} transfer by {adjustment:.5f} (slippage)"
@@ -91,9 +91,7 @@ def get_transfers(
             QueryParameter.date_type("EndTime", period_end),
         ])
 
-    negative_slippage = get_period_slippage(
-        dune, period_start, period_end, allow_positive=False
-    )
+    negative_slippage = get_period_slippage(dune, period_start, period_end).negative
     indexed_slippage = index_by(negative_slippage, 'solver_address')
 
     results = []

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -31,6 +31,9 @@ class TokenType(Enum):
         except KeyError as err:
             raise ValueError(f"No TransferType {type_str}!") from err
 
+    def __str__(self):
+        return self.value
+
 
 @dataclass
 class Transfer:
@@ -54,7 +57,8 @@ class Transfer:
 
         return cls(
             token_type=token_type,
-            token_address=Address(token_address) if token_type != TokenType.NATIVE else None,
+            token_address=Address(
+                token_address) if token_type != TokenType.NATIVE else None,
             receiver=Address(obj['receiver']),
             amount=float(obj['amount'])
         )
@@ -96,8 +100,8 @@ def get_transfers(
             transfer.add_slippage(indexed_slippage.get(transfer.receiver))
             if transfer.amount <= 0:
                 print(
-                    f"Slippage adjustment resulted in negative reimbursement!"
-                    f"Excluding eth transfer for solver {transfer.receiver}"
+                    f"Slippage adjustment resulted in negative reimbursement! \n"
+                    f"Excluding eth reimbursement for solver {transfer.receiver}"
                 )
                 continue
         results.append(transfer)

--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -90,6 +90,12 @@ def get_transfers(
         transfer = Transfer.from_dict(row)
         if transfer.token_type == TokenType.NATIVE:
             transfer.add_slippage(indexed_slippage.get(transfer.receiver))
+            if transfer.amount <= 0:
+                print(
+                    f"Slippage adjustment resulted in negative reimbursement!"
+                    f"Excluding eth transfer for solver {transfer.receiver}"
+                )
+                continue
         results.append(transfer)
 
 

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -20,7 +20,7 @@ class File:
         return self.filename()
 
 
-def write_to_csv(data_list: list, outfile: File):
+def write_to_csv(data_list: list[dataclass], outfile: File):
     """Writes `data_list` to `filename` as csv"""
     print(f"dumping {len(data_list)} results to {outfile.name}")
 

--- a/src/models.py
+++ b/src/models.py
@@ -41,6 +41,14 @@ class Address:
             return self.address == other.address
         return False
 
+    def __hash__(self):
+        return self.address.__hash__()
+
+    @classmethod
+    def zero(cls) -> Address:
+        """Returns Null Ethereum Address"""
+        return cls("0x0000000000000000000000000000000000000000")
+
     @staticmethod
     def _is_valid(address: str) -> bool:
         match_result = re.match(
@@ -101,14 +109,3 @@ class InternalTokenTransfer:
     ) -> list[InternalTokenTransfer]:
         """Filters records returning only Internal Trade types."""
         return cls.filter_by(recs, TransferType.INTERNAL_TRADE)
-
-
-@dataclass
-class SolverSlippage:
-    """Slippage per solver"""
-    eth_amount_wei: int
-    solver: Address
-
-    def __init__(self, eth_slippage_wei, solver):
-        self.eth_amount_wei = eth_slippage_wei
-        self.solver = Address(solver)

--- a/src/utils/dataset.py
+++ b/src/utils/dataset.py
@@ -8,12 +8,18 @@ def index_by(data_list: list[dataclass], field_str: str) -> dict[Any, dataclass]
     :param field_str: field of data class to index by
     :return: mapping of Account structures by account
     """
-    assert field_str in fields(data_list[0]), "index field does not exist on dataset"
+    if len(data_list) == 0:
+        return {}
+
+    field_names = {field.name for field in fields(data_list[0])}
+    assert field_str in field_names, \
+        f"index field {field_str} does not exist on {type(data_list[0])}"
 
     results = {}
     for entry in data_list:
-        if entry['field'] not in results:
-            results[entry['field']] = entry
+        index_key = entry.__dict__.get(field_str)
+        if index_key not in results:
+            results[index_key] = entry
         else:
             raise IndexError(f"Attempting to index by non-unique entry \"{entry}\"")
     return results

--- a/src/utils/dataset.py
+++ b/src/utils/dataset.py
@@ -10,10 +10,9 @@ def index_by(data_list: list[dataclass], field_str: str) -> dict[Any, dataclass]
     """
     if len(data_list) == 0:
         return {}
-
-    field_names = {field.name for field in fields(data_list[0])}
-    assert field_str in field_names, \
-        f"index field {field_str} does not exist on {type(data_list[0])}"
+    sample = data_list[0]
+    field_names = {field.name for field in fields(sample)}
+    assert field_str in field_names, f"{type(sample)} has no field \"{field_str}\""
 
     results = {}
     for entry in data_list:
@@ -21,5 +20,6 @@ def index_by(data_list: list[dataclass], field_str: str) -> dict[Any, dataclass]
         if index_key not in results:
             results[index_key] = entry
         else:
-            raise IndexError(f"Attempting to index by non-unique entry \"{entry}\"")
+            raise IndexError(
+                f"Attempting to index by non-unique index key \"{index_key}\"")
     return results

--- a/src/utils/dataset.py
+++ b/src/utils/dataset.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass, fields
+from typing import Any
+
+
+def index_by(data_list: list[dataclass], field_str: str) -> dict[Any, dataclass]:
+    """
+    :param data_list: list of Account structures (i.e. those having account field).
+    :param field_str: field of data class to index by
+    :return: mapping of Account structures by account
+    """
+    assert field_str in fields(data_list[0]), "index field does not exist on dataset"
+
+    results = {}
+    for entry in data_list:
+        if entry['field'] not in results:
+            results[entry['field']] = entry
+        else:
+            raise IndexError(f"Attempting to index by non-unique entry \"{entry}\"")
+    return results

--- a/tests/e2e/test_slippage_accounting.py
+++ b/tests/e2e/test_slippage_accounting.py
@@ -19,9 +19,10 @@ class TestDuneAnalytics(unittest.TestCase):
             period_start=datetime.strptime('2022-03-01', "%Y-%m-%d"),
             period_end=datetime.strptime('2022-03-02', "%Y-%m-%d"),
         )
-        assert (len(solver_slippages) > 0)
-        for slippage in solver_slippages:
-            assert (abs(slippage.amount_wei) < 2 * 10 ** 18)
+        self.assertLess(
+            solver_slippages.sum_positive() - solver_slippages.sum_negative(),
+            2 * 10 ** 18
+        )
 
 
 if __name__ == '__main__':

--- a/tests/e2e/test_slippage_accounting.py
+++ b/tests/e2e/test_slippage_accounting.py
@@ -14,14 +14,14 @@ class TestDuneAnalytics(unittest.TestCase):
         there should be manual investigations
         """
         dune = DuneAnalytics.new_from_environment()
-        slippage_accounting = get_period_slippage(
+        solver_slippages = get_period_slippage(
             dune=dune,
             period_start=datetime.strptime('2022-03-01', "%Y-%m-%d"),
             period_end=datetime.strptime('2022-03-02', "%Y-%m-%d"),
         )
-        assert (len(slippage_accounting) > 0)
-        for obj in slippage_accounting:
-            assert (abs(obj['eth_slippage_wei']) < 2 * 10 ** 18)
+        assert (len(solver_slippages) > 0)
+        for slippage in solver_slippages:
+            assert (abs(slippage.amount_wei) < 2 * 10 ** 18)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -5,14 +5,18 @@ from src.utils.dataset import index_by
 
 
 @dataclass
-class TestClass:
+class DummyDataClass:
     x: int
     y: str
 
 
 class MyTestCase(unittest.TestCase):
     def test_index_by(self):
-        data_set = [TestClass(1, "a"), TestClass(2, "b"), TestClass(3, "b")]
+        data_set = [
+            DummyDataClass(1, "a"),
+            DummyDataClass(2, "b"),
+            DummyDataClass(3, "b")
+        ]
         expected = {
             1: data_set[0],
             2: data_set[1],
@@ -20,11 +24,20 @@ class MyTestCase(unittest.TestCase):
         }
         self.assertEqual(index_by(data_set, 'x'), expected)
 
-        with self.assertRaises(IndexError):
+        with self.assertRaises(IndexError) as err:
             index_by(data_set, 'y')
 
-        with self.assertRaises(AssertionError):
-            index_by(data_set, 'non-existent field')
+        self.assertEqual(
+            str(err.exception),
+            "Attempting to index by non-unique index key \"b\""
+        )
+        bad_field = 'xxx'
+        with self.assertRaises(AssertionError) as err:
+            index_by(data_set, bad_field)
+        self.assertEqual(
+            str(err.exception),
+            f"<class \'test_data_utils.DummyDataClass\'> has no field \"{bad_field}\""
+        )
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -1,0 +1,31 @@
+import unittest
+from dataclasses import dataclass
+
+from src.utils.dataset import index_by
+
+
+@dataclass
+class TestClass:
+    x: int
+    y: str
+
+
+class MyTestCase(unittest.TestCase):
+    def test_index_by(self):
+        data_set = [TestClass(1, "a"), TestClass(2, "b"), TestClass(3, "b")]
+        expected = {
+            1: data_set[0],
+            2: data_set[1],
+            3: data_set[2]
+        }
+        self.assertEqual(index_by(data_set, 'x'), expected)
+
+        with self.assertRaises(IndexError):
+            index_by(data_set, 'y')
+
+        with self.assertRaises(AssertionError):
+            index_by(data_set, 'non-existent field')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -15,8 +15,11 @@ class TestAddress(unittest.TestCase):
         self.invalid_address = '0x12'
 
     def test_invalid(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as err:
             Address(address=self.invalid_address)
+        self.assertEqual(
+            str(err.exception), f"Invalid Ethereum Address {self.invalid_address}"
+        )
 
     def test_valid(self):
         self.assertEqual(
@@ -51,8 +54,12 @@ class TestTransferType(unittest.TestCase):
         )
 
     def test_invalid(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as err:
             TransferType.from_str(self.invalid_type)
+        self.assertEqual(
+            str(err.exception),
+            f"No TransferType {self.invalid_type}!"
+        )
 
 
 class TestTransfer(unittest.TestCase):
@@ -80,20 +87,33 @@ class TestTransfer(unittest.TestCase):
         transfer.add_slippage(negative_slippage)
         self.assertAlmostEqual(transfer.amount, 1.0, delta=0.0000000001)
 
-    def test_errors(self):
+        overdraft_slippage = SolverSlippage(
+            solver_name="Test Solver",
+            solver_address=solver,
+            amount_wei=-2 * (10 ** 18)
+        )
+
+        with self.assertRaises(ValueError) as err:
+            transfer.add_slippage(overdraft_slippage)
+        self.assertEqual(
+            str(err.exception),
+            f"Invalid adjustment {transfer} by {overdraft_slippage.amount_wei / 10 ** 18}"
+        )
+
+    def test_receiver_error(self):
         transfer = Transfer(
             token_type=TokenType.NATIVE,
             token_address=None,
             receiver=ONE_ADDRESS,
             amount=1.0
         )
-        slippage = SolverSlippage(
-            solver_name="Test Solver",
-            solver_address=TWO_ADDRESS,
-            amount_wei=0
-        )
-        with self.assertRaises(AssertionError):
-            transfer.add_slippage(slippage)
+        with self.assertRaises(AssertionError) as err:
+            transfer.add_slippage(SolverSlippage(
+                solver_name="Test Solver",
+                solver_address=TWO_ADDRESS,
+                amount_wei=0
+            ))
+            self.assertEqual(err, "receiver != solver")
 
     def test_from_dict(self):
         self.assertEqual(
@@ -111,21 +131,26 @@ class TestTransfer(unittest.TestCase):
             )
         )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as err:
             Transfer.from_dict({
                 "token_type": 'erc20',
                 "token_address": None,
                 "receiver": ONE_ADDRESS.address,
                 "amount": "1.234"
             })
-
-        with self.assertRaises(ValueError):
+        self.assertEqual(
+            str(err.exception), "ERC20 transfers must have valid token_address"
+        )
+        with self.assertRaises(ValueError) as err:
             Transfer.from_dict({
                 "token_type": 'native',
                 "token_address": ONE_ADDRESS.address,
                 "receiver": ONE_ADDRESS.address,
                 "amount": "1.234"
             })
+        self.assertEqual(
+            str(err.exception), "Native transfers must have null token_address"
+        )
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,6 +4,9 @@ from src.fetch.period_slippage import SolverSlippage
 from src.fetch.transfer_file import Transfer, TokenType
 from src.models import Address, TransferType
 
+ONE_ADDRESS = Address("0x1111111111111111111111111111111111111111")
+TWO_ADDRESS = Address("0x2222222222222222222222222222222222222222")
+
 
 class TestAddress(unittest.TestCase):
     def setUp(self) -> None:
@@ -81,12 +84,12 @@ class TestTransfer(unittest.TestCase):
         transfer = Transfer(
             token_type=TokenType.NATIVE,
             token_address=None,
-            receiver=Address("0x1111111111111111111111111111111111111111"),
+            receiver=ONE_ADDRESS,
             amount=1.0
         )
         slippage = SolverSlippage(
             solver_name="Test Solver",
-            solver_address=Address("0x2222222222222222222222222222222222222222"),
+            solver_address=TWO_ADDRESS,
             amount_wei=0
         )
         with self.assertRaises(AssertionError):
@@ -97,13 +100,13 @@ class TestTransfer(unittest.TestCase):
             Transfer.from_dict({
                 "token_type": 'native',
                 "token_address": None,
-                "receiver": "0x1111111111111111111111111111111111111111",
+                "receiver": ONE_ADDRESS.address,
                 "amount": "1.234"
             }),
             Transfer(
                 token_type=TokenType.NATIVE,
                 token_address=None,
-                receiver=Address("0x1111111111111111111111111111111111111111"),
+                receiver=ONE_ADDRESS,
                 amount=1.234
             )
         )
@@ -112,15 +115,15 @@ class TestTransfer(unittest.TestCase):
             Transfer.from_dict({
                 "token_type": 'erc20',
                 "token_address": None,
-                "receiver": "0x1111111111111111111111111111111111111111",
+                "receiver": ONE_ADDRESS.address,
                 "amount": "1.234"
             })
 
         with self.assertRaises(ValueError):
             Transfer.from_dict({
                 "token_type": 'native',
-                "token_address": "0x1111111111111111111111111111111111111111",
-                "receiver": "0x1111111111111111111111111111111111111111",
+                "token_address": ONE_ADDRESS.address,
+                "receiver": ONE_ADDRESS.address,
                 "amount": "1.234"
             })
 


### PR DESCRIPTION
When generating transfer files for solver reimbursements, we deduct the negative slippage. If the slippage adjustment results in negative reimbursement, we exclude the transfer.

## Test plan

New unit tests for all the introduced functionality!