### PR TITLE
Excluding settlements with zero AMM interactions only if several internal trades are made

### DIFF
--- a/tests/e2e/test_internal_trades.py
+++ b/tests/e2e/test_internal_trades.py
@@ -196,6 +196,7 @@ class TestDuneAnalytics(unittest.TestCase):
         """
         tx: 0x1b4a299bfd2bb97e2289260495f566b750b9b62856b061f31d5186ae3b5ddce7
         This tx has an illegal internal buffer trade, it was not allowed to sell UBI
+        to the contract
         """
         internal_transfers = get_internal_transfers(
             dune=self.dune_connection,
@@ -211,6 +212,12 @@ class TestDuneAnalytics(unittest.TestCase):
                 "0xDd1Ad9A21Ce722C151A836373baBe42c868cE9a4", internal_transfers
             ),
             3262425415624260124672,
+        )
+        self.assertEqual(
+            token_slippage(
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", internal_transfers
+            ),
+            -61150200744955688,
         )
 
     def test_buffer_trade_without_gp_settlement_price(self):


### PR DESCRIPTION
Previously, we decided to exclude all settlements that have zero AMM interactions. This was benefital for solver that did provide solutions with 0 AMM interactions, but were illegal. Now, they are reconsidered - if the transactions only settled 1 order - and the illegal tx will generate a token imbalance - which will then be considered in the overall slippage calculation.

But for settlements that have zero AMM interactions and several trades, we still stay to the same rule as before, as for these batches our mechanism of finding batches and classifying illegal trades does not work well enough.

Testplan:
Unit tests only