### PR TITLE
[Easy] Only Add Slipage when Found

### DIFF
--- a/src/fetch/transfer_file.py
+++ b/src/fetch/transfer_file.py
@@ -74,10 +74,8 @@ class Transfer:
             amount=float(obj["amount"]),
         )
 
-    def add_slippage(self, slippage: Optional[SolverSlippage]) -> None:
+    def add_slippage(self, slippage: SolverSlippage) -> None:
         """Adds Adjusts Transfer amount by Slippage amount"""
-        if slippage is None:
-            return
         assert self.receiver == slippage.solver_address, "receiver != solver"
         adjustment = slippage.amount_wei / 10**18
         print(
@@ -108,10 +106,8 @@ def get_transfers(dune: DuneAnalytics, period: AccountingPeriod) -> list[Transfe
     results = []
     for row in reimbursements_and_rewards:
         transfer = Transfer.from_dict(row)
-        if transfer.token_type == TokenType.NATIVE:
-            slippage: SolverSlippage = indexed_slippage.get(
-                transfer.receiver, SolverSlippage(transfer.receiver, "Unknown", 0)
-            )
+        slippage = indexed_slippage.get(transfer.receiver)
+        if transfer.token_type == TokenType.NATIVE and slippage is not None:
             try:
                 transfer.add_slippage(slippage)
             except ValueError as err:


### PR DESCRIPTION
Before we were calling dict.get() with a default of unknown (this was mostly to make type checker happy, but resulted in a bunch of silly print statements). This PR removes all that silly complication and results in clean logs.


Before
```
Fetching Slippage Accounting on Network.MAINNET...
got 18 records from last query
Adjusting 0x080a8b1E2f3695E179453c5e617b72A381BE44B9(Unknown) transfer by 0.00000 (slippage)
Adjusting 0x0d2584DA2F637805071f184bCFa1268eBAe8a24A(Unknown) transfer by 0.00000 (slippage)
Adjusting 0x15F4c337122Ec23859EC73Bec00aB38445E45304(Unknown) transfer by 0.00000 (slippage)
Adjusting 0x22DEE0935c77d32c7241362b14e76fc2D5eF657d(Unknown) transfer by 0.00000 (slippage)
Adjusting 0x2d15894FaC906386fF7f4Bd07fcEAc43fcF80C73(Unknown) transfer by 0.00000 (slippage)
Adjusting 0x340185114F9D2617DC4c16088d0375D09fee9186(prod-Naive) transfer by -0.00627 (slippage)
Adjusting 0x77ec2A722c2393D3fD64617BBaF1499C713e616b(prod-QuasiModo) transfer by -0.01120 (slippage)
Adjusting 0x833f076D182123cA8DDE2743045Ea02957bD61ef(Unknown) transfer by 0.00000 (slippage)
Adjusting 0x8ccc61dBA297833dbe5D95FD6360f106b9A7576e(barn-Naive) transfer by -0.00012 (slippage)
Adjusting 0xa0044c620Da7f2876dA7004719b8370eb7BE5e50(Unknown) transfer by 0.00000 (slippage)
Adjusting 0xa97DEF4fBCBa3b646dd169Bc2eeE40f0f3fE7771(Unknown) transfer by 0.00000 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-Quasimodo) transfer by -0.21433 (slippage)
Adjusting 0xdAE69AffE582d36f330Ee1145995A53Fab670962(Unknown) transfer by 0.00000 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -0.53860 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.02015 (slippage)
Adjusting 0xe33062a24149f7801a48B2675Ed5111d3278F0f5(barn-1Inch) transfer by -0.02785 (slippage)
Adjusting 0xe92F359e6F05564849AFa933CE8F62b8007A1d5D(Unknown) transfer by 0.00000 (slippage)
Adjusting 0xf2D21ad3c88170D4AE52bBBeBA80Cb6078D276F4(Unknown) transfer by 0.00000 (slippage)
dumping 36 results to transfers-2022-03-01-to-2022-03-08.csv
Total ETH Funds needed: 73.79963503390223
Total COW Funds needed: 455100.0
```


After
```
Fetching ETH Reimbursement & COW Rewards on Network.MAINNET...
got 36 records from last query
Fetching Slippage Accounting on Network.MAINNET...
got 18 records from last query
Adjusting 0x340185114F9D2617DC4c16088d0375D09fee9186(prod-Naive) transfer by -0.00627 (slippage)
Adjusting 0x77ec2A722c2393D3fD64617BBaF1499C713e616b(prod-QuasiModo) transfer by -0.01120 (slippage)
Adjusting 0x8ccc61dBA297833dbe5D95FD6360f106b9A7576e(barn-Naive) transfer by -0.00012 (slippage)
Adjusting 0xda324c2f06d3544E7965767ce9ca536dcb67a660(barn-Quasimodo) transfer by -0.21433 (slippage)
Adjusting 0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718(prod-1inch) transfer by -0.53860 (slippage)
Adjusting 0xDe786877a10DBb7EBa25a4DA65aEcf47654F08ab(barn-0x) transfer by -0.02015 (slippage)
Adjusting 0xe33062a24149f7801a48B2675Ed5111d3278F0f5(barn-1Inch) transfer by -0.02785 (slippage)
dumping 36 results to transfers-2022-03-01-to-2022-03-08.csv
Total ETH Funds needed: 73.79963503390223
Total COW Funds needed: 455100.0
For solver payouts, paste the transfer file CSV Airdrop at:
```


## Test Plan 

CI - specifically Unit Tests

You can also check the logs by running
```
python -m src.fetch.transfer_file --start '2022-03-01'
```